### PR TITLE
#167285190 Admin Cancel trip 

### DIFF
--- a/server/controllers/Trips.js
+++ b/server/controllers/Trips.js
@@ -26,6 +26,20 @@ class Trip {
 			return reqResponses.internalError(res);
 		}
 	}
+
+	static async cancelTrip(req, res) {
+		try {
+			const tripStatus = req.body.status;
+			const tripId = req.params.id;
+			const cancelTrip = new TripModel({ tripStatus, tripId });
+			if (!await cancelTrip.cancelTrip()) {
+				return reqResponses.handleError(cancelTrip.result.status, cancelTrip.message, res);
+			}
+			return reqResponses.handleSuccess(200, 'Trip cancelled successfully', cancelTrip.result, res);
+		} catch (error) {
+			return reqResponses.internalError(res);
+		}
+	}
 }
 
 export default Trip;

--- a/server/models/Trips.js
+++ b/server/models/Trips.js
@@ -37,6 +37,32 @@ class Trips {
 			}
 		}
 	}
+
+	async cancelTrip() {
+		const id = parseInt(this.payload.tripId);
+		const obj = db.find(o => o.id === id);
+		if (!obj) {
+			this.result = { status: 404, message: `Trip id record '${id}' not found` };
+			return false;
+		}
+		if (obj.status === 'canceled') {
+			this.result = { status: 400, message: 'This trip is already cancelled' };
+			return false;
+		}
+		const tripCancel = {
+			id: obj.id,
+			seatingCapacity: obj.seatingCapacity,
+			busLicensenumber: obj.busLicensenumber,
+			origin: obj.origin,
+			destination: obj.destination,
+			tripDate: obj.tripDate,
+			fare: obj.fare,
+			status: this.payload.tripStatus || obj.status,
+		};
+		db.splice(obj.id - 1, 1, tripCancel);
+		this.result = tripCancel;
+		return true;
+	}
 }
 
 export default Trips;

--- a/server/routes/trips.js
+++ b/server/routes/trips.js
@@ -5,5 +5,6 @@ import Auth from '../middleware/Auth';
 const router = express.Router();
 
 router.post('/trips', Auth.checkAdmin, controllers.createTrip);
+router.patch('/trips/:id/cancel', Auth.checkAdmin, controllers.cancelTrip);
 
 export default router;

--- a/server/test/trip.test.js
+++ b/server/test/trip.test.js
@@ -117,4 +117,46 @@ describe('/TRIPS', () => {
 				done();
 			});
 	});
+
+	it('should check id is not available', (done) => {
+		chai.request(app)
+			.patch(`/api/v1/trips/${100000}/cancel`)
+			.set('authorization', `Bearer ${adminToken}`)
+			.send({
+				status: 'canceled',
+			})
+			.end((err, res) => {
+				res.should.have.status(404);
+				if (err) return done();
+				done();
+			});
+	});
+
+	it('should successfully cancel a trip', (done) => {
+		chai.request(app)
+			.patch(`/api/v1/trips/${1}/cancel`)
+			.set('authorization', `Bearer ${adminToken}`)
+			.send({
+				status: 'canceled',
+			})
+			.end((err, res) => {
+				res.should.have.status(200);
+				if (err) return done();
+				done();
+			});
+	});
+
+	it('should check if trip is successfully canceled', (done) => {
+		chai.request(app)
+			.patch(`/api/v1/trips/${1}/cancel`)
+			.set('authorization', `Bearer ${adminToken}`)
+			.send({
+				status: 'cancel',
+			})
+			.end((err, res) => {
+				res.should.have.status(400);
+				if (err) return done();
+				done();
+			});
+	});
 });


### PR DESCRIPTION
### What does this PR do?

- [x] adds admin cancel trip api endpoint.

### Description of the task to be completed?
- enable admin successfully update a trip as cancelled
### How should this be manually tested?

- [x] clone this repo to your machine using this [link](https://github.com/JosephNjuguna/WayFarerV1.git)
- [x] open the cloned folder in your editor and add a **.env** file
in the .env file add 
```
PORT = 3000
```
- [x] open your terminal and change directory into the folder where you cloned this repo:

to run test : 
```
npm test
```
to test api on postman
```
npm start
```
console should log : 
```
 api started on port 3000
```
on postman use the following api endpoint:
```
/api/v1/trips/:<trip_id>/cancel
```

### Any background context you want to provide?
---- all the testing data to use on postman is available in README  file.----
### Relevant pivotal tracker stories?
[#167285190](https://www.pivotaltracker.com/story/show/167285190)
