### PR TITLE
#167674804 user should not book a trip that is canceled.

### DIFF
--- a/server/models/Bookings.js
+++ b/server/models/Bookings.js
@@ -23,6 +23,10 @@ class Bookings {
 				this.result = `Please select seat number less than ${obj.seatingCapacity} and not 0`;
 				return false;
 			}
+			if (obj.status === 'canceled') {
+				this.result = `This trip id: ${tripInfo} is canceled and not available.`;
+				return false;
+			}
 			if (obj.tripdate < date.modernDate()) {
 				this.result = `Please select a current trip. this trip already happened on date ${obj.tripdate}.`;
 				return false;

--- a/server/models/Trips.js
+++ b/server/models/Trips.js
@@ -46,7 +46,7 @@ class Trips {
 			return false;
 		}
 		if (obj.status === 'canceled') {
-			this.result = { status: 400, message: 'This trip is already cancelled' };
+			this.result = { status: 400, message: 'This trip is already canceled' };
 			return false;
 		}
 		const tripCancel = {

--- a/server/test/trip.test.js
+++ b/server/test/trip.test.js
@@ -143,34 +143,6 @@ describe('/TRIPS AND BOOKINGS', () => {
 			});
 	});
 
-	it('should successfully cancel a trip', (done) => {
-		chai.request(app)
-			.patch(`/api/v1/trips/${1}/cancel`)
-			.set('authorization', `Bearer ${adminToken}`)
-			.send({
-				status: 'canceled',
-			})
-			.end((err, res) => {
-				res.should.have.status(200);
-				if (err) return done();
-				done();
-			});
-	});
-
-	it('should check if trip is successfully canceled', (done) => {
-		chai.request(app)
-			.patch(`/api/v1/trips/${1}/cancel`)
-			.set('authorization', `Bearer ${adminToken}`)
-			.send({
-				status: 'cancel',
-			})
-			.end((err, res) => {
-				res.should.have.status(400);
-				if (err) return done();
-				done();
-			});
-	});
-
 	it('should show that token is required', (done) => {
 		chai.request(app)
 			.get('/api/v1/trips')
@@ -395,6 +367,49 @@ describe('/TRIPS AND BOOKINGS', () => {
 			.set('authorization', `Bearer ${userToken}`)
 			.end((err, res) => {
 				res.should.have.status(200);
+				if (err) return done();
+				done();
+			});
+	});
+
+	it('should successfully cancel a trip', (done) => {
+		chai.request(app)
+			.patch(`/api/v1/trips/${1}/cancel`)
+			.set('authorization', `Bearer ${adminToken}`)
+			.send({
+				status: 'canceled',
+			})
+			.end((err, res) => {
+				res.should.have.status(200);
+				if (err) return done();
+				done();
+			});
+	});
+
+	it('should check if trip is successfully canceled', (done) => {
+		chai.request(app)
+			.patch(`/api/v1/trips/${1}/cancel`)
+			.set('authorization', `Bearer ${adminToken}`)
+			.send({
+				status: 'canceled',
+			})
+			.end((err, res) => {
+				res.should.have.status(400);
+				if (err) return done();
+				done();
+			});
+	});
+
+	it('should not book a canceled trip', (done) => {
+		chai.request(app)
+			.post('/api/v1/bookings')
+			.set('authorization', `Bearer ${userToken}`)
+			.send({
+				tripId: 1,
+				seatNumber: 1,
+			})
+			.end((err, res) => {
+				res.should.have.status(404);
 				if (err) return done();
 				done();
 			});


### PR DESCRIPTION
### What does this PR do?

- [x] fix bug where user can book a trip that is canceled

### Description of the task to be completed?

- [x] enable a user, not to book trips that are canceled

### How should this be manually tested?

- [x] clone this repo to your machine using this [link](https://github.com/JosephNjuguna/WayFarerV1.git)
- [x] open the cloned folder in your editor and add a **.env** file
in the .env file add 
```
EMAIL = admin@wayfarer.com
PASSWORD = @12Admin
PORT = 3000
JWT_KEY= 'wayfarer@12'
```
- [x] open your terminal and change directory into the folder where you cloned this repo:

to run test : 
```
npm test
```
to test api on postman
```
npm start
```
console should log : 
```
 api started on port 3000
```
on postman test the api endpoint provided:
first, cancel a trip
```
/api/v1/trips/1/cancel
```
try to book the canceled trip on this api endpoint :
#### body
```
tripId: 1
seatNumber :10 
```
api
```
/api/v1/bookings
```
### Any background context you want to provide?
---- all the testing data to use on postman is available in README  file.----
### Relevant pivotal tracker stories?
[#167674804](https://www.pivotaltracker.com/story/show/167674804)
