### PR TITLE
#167750266 fix view trips api endpoint.

### DIFF
--- a/server/controllers/Trips.js
+++ b/server/controllers/Trips.js
@@ -1,4 +1,5 @@
 /* eslint-disable consistent-return */
+import jwt from 'jsonwebtoken';
 import TripModel from '../models/Trips';
 import reqResponses from '../helpers/Responses';
 
@@ -42,7 +43,17 @@ class Trip {
 	}
 
 	static async viewAlltrips(req, res) {
-		const viewTrips = await TripModel.viewAlltrips();
+		const token = req.headers.authorization.split(' ')[1];
+		const decoded = jwt.verify(token, process.env.JWT_KEY);
+		req.userData = decoded;
+		if (req.userData.isAdmin === true) {
+			const viewTrips = await TripModel.viewAlltrips();
+			if (!viewTrips) {
+				return reqResponses.handleError(404, 'No Trips record found', res);
+			}
+			return reqResponses.handleSuccess(200, 'success', viewTrips, res);
+		}
+		const viewTrips = await TripModel.viewActivetrip();
 		if (!viewTrips) {
 			return reqResponses.handleError(404, 'No Trips record found', res);
 		}
@@ -50,8 +61,19 @@ class Trip {
 	}
 
 	static async viewSingletrip(req, res) {
+		const token = req.headers.authorization.split(' ')[1];
+		const decoded = jwt.verify(token, process.env.JWT_KEY);
+		req.userData = decoded;
+		if (req.userData.isAdmin === true) {
+			const tripId = req.params.id;
+			const singleTrip = await TripModel.viewSingletrip(tripId);
+			if (!singleTrip) {
+				return reqResponses.handleError(404, 'Trip Id not found', res);
+			}
+			return reqResponses.handleSuccess(200, 'success', singleTrip, res);
+		}
 		const tripId = req.params.id;
-		const singleTrip = await TripModel.viewSingletrip(tripId);
+		const singleTrip = await TripModel.viewSingleActivetrip(tripId);
 		if (!singleTrip) {
 			return reqResponses.handleError(404, 'Trip Id not found', res);
 		}

--- a/server/controllers/Trips.js
+++ b/server/controllers/Trips.js
@@ -47,14 +47,14 @@ class Trip {
 		const decoded = jwt.verify(token, process.env.JWT_KEY);
 		req.userData = decoded;
 		if (req.userData.isAdmin === true) {
-			const viewTrips = await TripModel.viewAlltrips();
-			if (!viewTrips) {
+			const viewTrips = new TripModel();
+			if (!await viewTrips.viewAlltrips()) {
 				return reqResponses.handleError(404, 'No Trips record found', res);
 			}
 			return reqResponses.handleSuccess(200, 'success', viewTrips, res);
 		}
-		const viewTrips = await TripModel.viewActivetrip();
-		if (!viewTrips) {
+		const viewTrips = new TripModel();
+		if (!await viewTrips.viewActivetrips()) {
 			return reqResponses.handleError(404, 'No Trips record found', res);
 		}
 		return reqResponses.handleSuccess(200, 'success', viewTrips, res);
@@ -66,15 +66,15 @@ class Trip {
 		req.userData = decoded;
 		if (req.userData.isAdmin === true) {
 			const tripId = req.params.id;
-			const singleTrip = await TripModel.viewSingletrip(tripId);
-			if (!singleTrip) {
+			const singleTrip = new TripModel(tripId);
+			if (!await singleTrip.viewSingletrip()) {
 				return reqResponses.handleError(404, 'Trip Id not found', res);
 			}
 			return reqResponses.handleSuccess(200, 'success', singleTrip, res);
 		}
 		const tripId = req.params.id;
-		const singleTrip = await TripModel.viewSingleActivetrip(tripId);
-		if (!singleTrip) {
+		const singleTrip = new TripModel(tripId);
+		if (!await singleTrip.viewSingleActivetrip()) {
 			return reqResponses.handleError(404, 'Trip Id not found', res);
 		}
 		return reqResponses.handleSuccess(200, 'success', singleTrip, res);

--- a/server/models/Trips.js
+++ b/server/models/Trips.js
@@ -58,7 +58,7 @@ class Trips {
 		return true;
 	}
 
-	static async viewAlltrips() {
+	async viewAlltrips() {
 		if (db.length === 0) {
 			return false;
 		}
@@ -66,7 +66,7 @@ class Trips {
 		return this.result;
 	}
 
-	static async viewActivetrip() {
+	async viewActivetrips() {
 		// eslint-disable-next-line radix
 		const obj = db.find(o => o.status === 'active');
 		if (!obj) {
@@ -76,9 +76,9 @@ class Trips {
 		return this.result;
 	}
 
-	static async viewSingletrip(tripId) {
+	async viewSingletrip() {
 		// eslint-disable-next-line radix
-		const id = parseInt(tripId);
+		const id = parseInt(this.payload);
 		const obj = db.find(o => o.id === id);
 		if (!obj) {
 			return false;
@@ -87,9 +87,9 @@ class Trips {
 		return this.result;
 	}
 
-	static async viewSingleActivetrip(tripId) {
+	async viewSingleActivetrip() {
 		// eslint-disable-next-line radix
-		const id = parseInt(tripId);
+		const id = parseInt(this.payload);
 		const obj = db.find(o => o.id === id && o.status === 'active');
 		if (!obj) {
 			return false;

--- a/server/models/Trips.js
+++ b/server/models/Trips.js
@@ -2,7 +2,6 @@
 /* eslint-disable no-else-return */
 /* eslint-disable radix */
 import db from '../Db/trips';
-import date from '../helpers/Date';
 
 class Trips {
 	constructor(payload = null) {
@@ -22,7 +21,7 @@ class Trips {
 			fare: parseInt(this.payload.fare),
 			status: 'active',
 		};
-		const obj = db.find(o => o.busLicensenumber === this.payload.busLicensenumber || o.tripDate === this.payload.tripDate);
+		const obj = db.find(o => o.busLicensenumber === this.payload.busLicensenumber && o.tripDate === this.payload.tripDate);
 		if (!obj) {
 			db.push(bookingData);
 			this.result = bookingData;
@@ -31,7 +30,6 @@ class Trips {
 			this.result = { status: 409, message: 'Trip already exist.' };
 			return false;
 		}
-
 	}
 
 	async cancelTrip() {
@@ -68,10 +66,31 @@ class Trips {
 		return this.result;
 	}
 
+	static async viewActivetrip() {
+		// eslint-disable-next-line radix
+		const obj = db.find(o => o.status === 'active');
+		if (!obj) {
+			return false;
+		}
+		this.result = obj;
+		return this.result;
+	}
+
 	static async viewSingletrip(tripId) {
 		// eslint-disable-next-line radix
 		const id = parseInt(tripId);
 		const obj = db.find(o => o.id === id);
+		if (!obj) {
+			return false;
+		}
+		this.result = obj;
+		return this.result;
+	}
+
+	static async viewSingleActivetrip(tripId) {
+		// eslint-disable-next-line radix
+		const id = parseInt(tripId);
+		const obj = db.find(o => o.id === id && o.status === 'active');
 		if (!obj) {
 			return false;
 		}

--- a/server/test/trip.test.js
+++ b/server/test/trip.test.js
@@ -26,6 +26,17 @@ describe('/TRIPS AND BOOKINGS', () => {
 	it('should check no trips record', (done) => {
 		chai.request(app)
 			.get('/api/v1/trips')
+			.set('authorization', `Bearer ${adminToken}`)
+			.end((err, res) => {
+				res.should.have.status(404);
+				if (err) return done();
+				done();
+			});
+	});
+
+	it('should check no active trips record by user', (done) => {
+		chai.request(app)
+			.get('/api/v1/trips')
 			.set('authorization', `Bearer ${userToken}`)
 			.end((err, res) => {
 				res.should.have.status(404);
@@ -275,7 +286,7 @@ describe('/TRIPS AND BOOKINGS', () => {
 			});
 	});
 
-	it('should check all trips', (done) => {
+	it('should check all trips admin', (done) => {
 		chai.request(app)
 			.get('/api/v1/trips')
 			.set('authorization', `Bearer ${userToken}`)
@@ -286,7 +297,29 @@ describe('/TRIPS AND BOOKINGS', () => {
 			});
 	});
 
+	it('should check only active trips', (done) => {
+		chai.request(app)
+			.get('/api/v1/trips')
+			.set('authorization', `Bearer ${adminToken}`)
+			.end((err, res) => {
+				res.should.have.status(200);
+				if (err) return done();
+				done();
+			});
+	});
+
 	it('should check single trip', (done) => {
+		chai.request(app)
+			.get('/api/v1/trips/1')
+			.set('authorization', `Bearer ${adminToken}`)
+			.end((err, res) => {
+				res.should.have.status(200);
+				if (err) return done();
+				done();
+			});
+	});
+
+	it('should check single active trip user', (done) => {
 		chai.request(app)
 			.get('/api/v1/trips/1')
 			.set('authorization', `Bearer ${userToken}`)


### PR DESCRIPTION
### What does this PR do?

adds filter function where only admin can view all trips

adds filter function where user can only view active trips

### Description of the task to be completed?

- [x] enable a user to view only active trips

- [x] enable admin view all trips

### How should this be manually tested?
- [x] clone this repo to your machine using this [link](https://github.com/JosephNjuguna/WayFarerV1.git)
- [x] open the cloned folder in your editor and add a **.env** file
in the .env file add 
```
EMAIL = admin@wayfarer.com
PASSWORD = @12Admin
JWT_KEY= 'wayfarer@12'
PORT = 3000
```
- [x] open your terminal and change directory into the folder where you cloned this repo:

to run test : 
```
npm test
```
to test api on postman
```
npm start
```
console should log : 
```
 api started on port 3000
```
on postman/insomnia use the following api endpoint:
**GET**
```
/api/v1/trips
```
**GET**
```
/api/v1/trips/1
```

### Any background context you want to provide?
---- all the testing data to use on postman is available in README  file.----
### Relevant pivotal tracker stories?
[#167750266](https://www.pivotaltracker.com/story/show/167750266)
### Screenshots available: 
the admin can view all trips.
![Screenshot from 2019-08-07 08-17-30](https://user-images.githubusercontent.com/44730807/62596819-78345900-b8ec-11e9-8024-f777d46cdbf0.png)
the user can only view active trips.
![Screenshot from 2019-08-07 08-17-38](https://user-images.githubusercontent.com/44730807/62596841-9601be00-b8ec-11e9-959d-e508d8fa998f.png)

