### PR TITLE
#167802304 fix create trip endpoint

### DIFF
--- a/server/middleware/Validations.js
+++ b/server/middleware/Validations.js
@@ -89,7 +89,7 @@ class Validations {
 		}
 		const data = req.body;
 		const schema = Joi.object().keys({
-			seatingCapacity: Joi.string().regex(/^[1-9]+$/).required().error(new Error('Invalid seating capacity. ensure you have number only e.g 12 or 20')),
+			seatingCapacity: Joi.string().regex(/^[0-9]*[1-9][0-9]*$/).required().error(new Error('Invalid seating capacity. ensure you have number only e.g 12 or 20')),
 
 			busLicensenumber: Joi.string().required().regex(/^([a-zA-Z])+(\s)+[0-999]+$/).error(new Error('Invalid bus license number.should have this format e.g RAD 123')),
 
@@ -99,7 +99,7 @@ class Validations {
 			// eslint-disable-next-line newline-per-chained-call
 			tripDate: Joi.date().min(new Date()).format(['DD/MM/YYYY', 'DD-MM-YYYY']).iso().required().error(new Error('Invalid DATE. enter a current date and follow this format: DD/MM/YYYY or DD-MM-YYYY e.g 01/01/2019 or 01-01-2019')),
 
-			fare: Joi.string().regex(/^[0-9]*$/).required().error(new Error('Invalid fare value. ensure you have numbers only. eg 2000')),
+			fare: Joi.string().regex(/^[0-9]*[1-9][0-9]*$/).required().error(new Error('Invalid fare value. ensure you have numbers only. eg 2000')),
 		});
 		Joi.validate(data, schema, (err) => {
 			if (err) {


### PR DESCRIPTION
### What does this PR do?

updates trip validations.

### Description of the task to be completed?

- [x] enable admin to create a trip with the right value as fare

### How should this be manually tested?
- [x] clone this repo to your machine using this [link](https://github.com/JosephNjuguna/WayFarerV1.git)
- [x] open the cloned folder in your editor and add a **.env** file
in the .env file add 
```
EMAIL = admin@wayfarer.com
PASSWORD = @12Admin
JWT_KEY= 'wayfarer@12'
PORT = 3000
```
- [x] open your terminal and change directory into the folder where you cloned this repo:

to run test : 
```
npm test
```
to test api on postman
```
npm start
```
console should log : 
```
 api started on port 3000
```
on postman/insomnia use the following api endpoint:
**POST**
```
/api/v1/trips
```
### Any background context you want to provide?
---- all the testing data to use on postman is available in README  file.----
### Relevant pivotal tracker stories?
[#167802304](https://www.pivotaltracker.com/story/show/167802304)
### Screenshots available: 
![Screenshot from 2019-08-09 09-50-27](https://user-images.githubusercontent.com/44730807/62759888-4c030e80-ba8b-11e9-8423-dd43485cf277.png)


