### PR TITLE
#167772559 admin cancel trip endpoint(database).

### DIFF
--- a/server/test/trip.test.js
+++ b/server/test/trip.test.js
@@ -476,23 +476,23 @@ describe('/TRIPS AND BOOKINGS', () => {
 			});
 	});
 
-	it('should successfully show user no trip id record found for his/her booking', (done) => {
-		chai.request(app)
-			.delete('/api/v2/bookings/1000000')
-			.set('authorization', `Bearer ${userToken}`)
-			.end((err, res) => {
-				res.should.have.status(404);
-				if (err) return done();
-				done();
-			});
-	});
-
 	it('should successfully show invalid booking id', (done) => {
 		chai.request(app)
 			.delete('/api/v2/bookings/one')
 			.set('authorization', `Bearer ${userToken}`)
 			.end((err, res) => {
 				res.should.have.status(400);
+				if (err) return done();
+				done();
+			});
+	});
+
+	it('should successfully show user no trip id record found for his/her booking', (done) => {
+		chai.request(app)
+			.delete('/api/v2/bookings/1000000')
+			.set('authorization', `Bearer ${userToken}`)
+			.end((err, res) => {
+				res.should.have.status(404);
 				if (err) return done();
 				done();
 			});
@@ -574,7 +574,7 @@ describe('/TRIPS AND BOOKINGS', () => {
 				seatNumber: 1,
 			})
 			.end((err, res) => {
-				res.should.have.status(404);
+				res.should.have.status(400);
 				if (err) return done();
 				done();
 			});


### PR DESCRIPTION
### What does this PR do?

- [x] adds admin cancel trip api endpoint.

### Description of the task to be completed?
- enable admin successfully update a trip as **canceled**
### How should this be manually tested?

- [x] clone this repo to your machine using this [link](https://github.com/JosephNjuguna/WayFarerV1.git)
- [x] open the cloned folder in your editor and add a **.env** file
in the .env file add 
```
.env data is provided in the readme file.
```
- [x] open your terminal and change directory into the folder where you cloned this repo:

to run test : 
```
npm test
```
to test api on postman
```
npm start
```
on postman use the following api endpoint:
```
/api/v2/trips/:<trip_id>/cancel
```

### Any background context you want to provide?
---- all the testing data to use on postman is available in README  file.----
- only the admin can access this route. 
- admin can`t cancel a canceled trip.

### Relevant pivotal tracker stories?
[#167772559](https://www.pivotaltracker.com/story/show/167772559)

### Screenshots Available : 
**Cancel Trip Success**
![Screenshot from 2019-08-13 08-05-04](https://user-images.githubusercontent.com/44730807/62922311-c3021500-bdb3-11e9-809b-6660d57b85ba.png)

**Admin should not cancel trip twice**

![Screenshot from 2019-08-13 08-05-19](https://user-images.githubusercontent.com/44730807/62922462-15433600-bdb4-11e9-84d1-2c7a1eb9fcbb.png)


